### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/wf.yml
+++ b/.github/workflows/wf.yml
@@ -25,12 +25,20 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
+      # Set up Node.js
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+      # Install dependencies
+      - name: Install dependencies
+        run: npm install
+
+      # Build the project
+      - name: Build the project
+        run: npm run build
+
+      # Deploy the project
+      - name: Deploy the project
+        run: npm run deploy

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "author": "",
   "license": "ISC",
-  "homepage": "https://githubnext.github.io/workspace-blank",
+  "homepage": "https://jc9677.github.io/minesweeper",
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
Update the workflow for GitHub Pages deployment.

* **package.json**
  - Update the `homepage` field to `"https://jc9677.github.io/minesweeper"`

* **.github/workflows/wf.yml**
  - Add a step to set up Node.js using `actions/setup-node@v2`
  - Add a step to install dependencies using `npm install`
  - Add a step to build the project using `npm run build`
  - Add a step to deploy the project using `npm run deploy`

