### PR TITLE
Fix build process by updating Babel dependencies

### DIFF
--- a/.github/workflows/wf.yml
+++ b/.github/workflows/wf.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # Install Babel dependencies
+      - name: Install Babel dependencies
+        run: npm install @babel/core@^7.16.0
+
       # Build the project
       - name: Build the project
         run: npm run build


### PR DESCRIPTION
Add a step to install Babel dependencies before the build step in the GitHub Actions workflow.

* **Install Babel dependencies**
  - Add a step to install Babel dependencies with the required version "^7.16.0" before the build step in `.github/workflows/wf.yml`.

